### PR TITLE
Rtd 14: Integracion continua 

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -5,12 +5,10 @@ on:
     branches:
       #- main
       - develop #Cambio a rama develop porque la rama main no tiene todavia la estructura para compilar
-  #pull_request:
-  #  branches:
-  #    - develop
-
+  
 jobs:
-  build:
+  build-and-test:
+    name: Test & Compile
     runs-on: ubuntu-latest
 
     steps:
@@ -26,14 +24,14 @@ jobs:
       run: |
         python3 -m pip install --upgrade platformio
 
+    - name: Testing with PlatformIO
+      run: |
+          platformio test --environment unit 
+    
+    
     - name: Compile with PlatformIO
       run: |
-        platformio run
-
-#    - name: Upload firmware artifact
-#      if: always()
-#      uses: actions/upload-artifact@v3
-#      with:
-#        name: blinkled-firmware
-#        path: ./.pio/build/esp32dev/firmware.bin
+          platformio run --environment esp32dev 
+    
+    
 

--- a/firmware/test/test_main.cpp
+++ b/firmware/test/test_main.cpp
@@ -1,0 +1,35 @@
+//#include <Arduino.h>
+#include <ArduinoFake.h>
+#include <unity.h>
+
+using namespace fakeit;
+
+// Define el pin del LED (por ejemplo, el pin 2 para la ESP32)
+#define LED_PIN 2
+
+
+
+void test_example(void)
+{
+    When(Method(ArduinoFake(), digitalWrite)).AlwaysReturn();
+    When(Method(ArduinoFake(), delay)).AlwaysReturn();
+
+    loop();
+
+    Verify(Method(ArduinoFake(), digitalWrite).Using(LED_PIN, HIGH)).Once();
+    Verify(Method(ArduinoFake(), digitalWrite).Using(LED_PIN, LOW)).Once();
+    Verify(Method(ArduinoFake(), delay).Using(100)).Exactly(2_Times);
+}
+
+
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+
+    RUN_TEST(test_example);
+ 
+    UNITY_END();
+
+    return 0;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,5 +20,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 
+[env:unit]
+platform = native
+lib_deps = ArduinoFake
+test_build_src = true
 
 


### PR DESCRIPTION
Se agrega la parte de testing unitario a github-actions

1- Se crea el archivo de testing en el directorio /test
2- Se agrega el entorno de native en platformio.ini
3- Si estan trabajando sobre el host para probar el test , desde la consola de platformio ejecutar:
    platformio test --environment unit
4- Si estan trabajando sobre el host para probar la compilacion , desde la consola de platformio ejecutar:
    platformio run --environment esp32dev
5- Por ultimo, modificar el  archivo .github/workflows/ci-esp32.yml  y agregar los pasos 3 y 4 anteriormente


 
 
     
    